### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Currently supports following attributes for django conversion:
 
 ```
 dj-for   => will create a for loop
-dj-refs  => will create ref to variable
+dj-ref   => will create ref to variable
 dj-if    => will create if block
 dj-block => will create a block
 ```


### PR DESCRIPTION
There is a tiny typo in the Readme that bugged me when I tried to use the export.py for the first time.